### PR TITLE
Select <i> tag within scientific name field

### DIFF
--- a/birdbot.py
+++ b/birdbot.py
@@ -20,7 +20,7 @@ bird = line['name'][0].lower() + line['name'][1:]
 entry = requests.get('http://en.wikipedia.org%s' % url)
 soup = BeautifulSoup(entry.text)
 
-scientific = soup.find(class_='binomial').text
+scientific = soup.find(class_='binomial').find('i').text
 
 # find thumbnail
 src = soup.find(class_='image').find('img')['src']


### PR DESCRIPTION
Without drilling down on the actual name bit, the bot could tweet brackets if there is a reference in the name. (Like [this one!!!!!](https://twitter.com/bird_facts_bot/status/816735959601426432)). You can select just the italic name, like I do in this pull request, or alternately split on left bracket like .split("[")[0]? Thanks!