### PR TITLE
Escape entire tweet text

### DIFF
--- a/birdbot.py
+++ b/birdbot.py
@@ -109,10 +109,11 @@ for tweet in tweets:
     # end at end of sentence
     text = re.sub(r'([\.?!\n\r]).*$', r'\g<1>', text)
     if len(fact + text) < 280 and len(text) > 5:
-        # avoid &amp; and similar
-        text = unescape(text)
 
         fact += text
+        # avoid &amp; and similar
+        fact = unescape(fact)
+
         print('tweet: twitter.com/%s/status/%d' % \
                 (tweet['user']['screen_name'], tweet['id']))
         print('original text: %s' % tweet['text'])


### PR DESCRIPTION
This prevents unescaped text in bird names (e.g. `The heuglin&#39;s francolin` --> `The heuglin's francolin`).

## Before
<img width="604" alt="image" src="https://user-images.githubusercontent.com/1572164/74592716-14ed5700-4ff2-11ea-8fea-857b55eec524.png">

 ## After
<img width="593" alt="image" src="https://user-images.githubusercontent.com/1572164/74592720-1fa7ec00-4ff2-11ea-8054-11b2a840840a.png">

